### PR TITLE
Fix crashes on respacks with invalid songs.

### DIFF
--- a/src/js/ResourcePack.js
+++ b/src/js/ResourcePack.js
@@ -379,7 +379,8 @@ class Respack {
 
         let newSongs = [];
         let el = dom.documentElement.firstElementChild;
-        for(; el; el = el.nextElementSibling) {
+        
+        for(let i = 0; el; el = el.nextElementSibling, i++) {
             let song = this.getSong(el.attributes[0].value);
             if(song) {
                 song.title = el.getTag("title");


### PR DESCRIPTION
Some respacks crash 0x40 when they have a missing song name.

This PR fixes this issue.

Not sure if we need a whole PR for this issue, feel free to close this if you wish to make the change yourself.