### PR TITLE
Add parseQueryString and packsURL to settings

### DIFF
--- a/src/js/HuesSettings.js
+++ b/src/js/HuesSettings.js
@@ -49,6 +49,9 @@ const defaultSettings = {
     firstImage: null,
     // set to false to never change images
     fullAuto: true,
+    // The remote respack listing JSON endpoint
+    // NOTE: Any packs referenced need CORS enabled or loads fail
+    packsURL: "https://cdn.0x40.ga/getRespacks.php",
     // If set, will disable the remote resources menu. For custom pages.
     disableRemoteResources: false,
     // You will rarely want to change this. Enables/disables the Hues Window.

--- a/src/js/HuesSettings.js
+++ b/src/js/HuesSettings.js
@@ -32,6 +32,8 @@ const defaultSettings = {
     workersPath : "lib/workers/",
     // List of respacks to load
     respacks : [],
+    // If true, the query string (?foo=bar&baz=boz) will be parsed for settings
+    parseQueryString : true,
     // ONLY USED FOR QUERY STRINGS this will be prepended to any respacks
     // passed in as a ?packs=query
     respackPath : "respacks/",
@@ -248,16 +250,18 @@ class HuesSettings {
             }
         }
 
-        let querySettings = this.getQuerySettings();
+        if (this.parseQueryString) {
+            let querySettings = this.getQuerySettings();
 
-        for(let attr in defaultSettings) {
-            // query string overrides, finally
-            if(querySettings[attr] !== undefined && attr != 'respacks') {
-                this.ephemerals[attr] = querySettings[attr];
+            for(let attr in defaultSettings) {
+                // query string overrides, finally
+                if(querySettings[attr] !== undefined && attr != 'respacks') {
+                    this.ephemerals[attr] = querySettings[attr];
+                }
             }
-        }
 
-        this.respacks = this.respacks.concat(querySettings.respacks);
+            this.respacks = this.respacks.concat(querySettings.respacks);
+        }
     }
 
     getQuerySettings() {

--- a/src/js/ResourceManager.js
+++ b/src/js/ResourceManager.js
@@ -31,9 +31,6 @@ let getAndIncrementUnique = function() {
     return unique++;
 };
 
-// NOTE: Any packs referenced need CORS enabled or loads fail
-let packsURL = "https://cdn.0x40.ga/getRespacks.php";
-
 class Resources {
     constructor(core, huesWin) {
         this.core = core;
@@ -719,7 +716,7 @@ class Resources {
         let item = this.appendSimpleListItem("Loading...", remoteList);
 
         let req = new XMLHttpRequest();
-        req.open('GET', packsURL, true);
+        req.open('GET', this.core.settings.packsURL, true);
         req.responseType = 'json';
         req.onload = () => {
             if(!req.response) {


### PR DESCRIPTION
Allows the query string parsing to be disabled (query string will still be parsed by default, `parseQueryString : true`) and changing the remote respack JSON listing endpoint without editing ResourceManager.js.

(Eager PR meant to be merged after #35, or maybe just this one, or something.)