### PR TITLE
Prevent an issue with "dark mode" browser extensions

### DIFF
--- a/src/css/hues-main.css
+++ b/src/css/hues-main.css
@@ -24,6 +24,7 @@
     overflow: hidden;
     font-family: 'PetMe64Web';
     position: relative;
+    background-color: transparent;
 }
 
 .hues-root h1, .hues-root h2, .hues-root h3 {


### PR DESCRIPTION
Hello,

I'm using a very popular extension called [DarkReader](https://darkreader.org/) and I noticed an issue on all 0x40 websites : It seems that images are not displayed correctly (in fact, the entire canvas isn't displayed at all)

**Issue description**
When using [DarkReader](https://darkreader.org/) (or other similar "dark mode" extensions), a common behavior is that it tries to put a black background-color on all pages. Because of that, and because the canvas is supposed to be the background of the page, the added back color prevents images to be displayed.

**Fix idea**
Set background-color to transparent in `hues-root` with an `!important` to make sure it's never overwritten. 

**Disclaimer**
I didn't do *lot* of tests, but it should be working, right? 