### PR TITLE
Only override loading button if respack unchanged

### DIFF
--- a/src/js/ResourceManager.ts
+++ b/src/js/ResourceManager.ts
@@ -830,7 +830,11 @@ export default class Resources {
         this.addAll([pack.url], (progress, respack) => {
                 this.remoteProgress(progress, respack);
             }
-        ).then(this.remoteComplete.bind(this));
+        ).then(() => {
+            if (pack === this.packView.pack) {
+                this.remoteComplete();
+            }
+        });
     }
 
     remoteProgress(progress: number, respack: Respack) {


### PR DESCRIPTION
If a respack is loaded then a different one is selected, the loading button still gets overridden on the new respack. This behaviour is slightly confusing and the PR fixes it :-)

The only point of confusion that might exist is if you select a different respack then re-select the one that is currently loading, it is labelled as already loaded. This is a minor confusion that exists anyways regardless of this PR but I stumbled onto it/exposed it a bit more.